### PR TITLE
Added clean errors method

### DIFF
--- a/valify/Validator.php
+++ b/valify/Validator.php
@@ -215,4 +215,8 @@ class Validator {
         foreach ($errors as $attr => $msgs)
             $this->_errors[$attr] = $msgs;
     }
+
+    public function cleanErrors() {
+        $this->_errors = [];
+    }
 }


### PR DESCRIPTION
It is very useful when you can reset errors array. When you validate array of data arrays you need to know errors only for current data array, but you get sum with previous errors. So, if call cleanErrors method, problem solves.
